### PR TITLE
fix<useTransactionDetails>: check for null on network change, repositioned loading icons on transactions

### DIFF
--- a/src/components/Hyperlink/index.ts
+++ b/src/components/Hyperlink/index.ts
@@ -1,0 +1,11 @@
+import React from 'react'
+import styled from 'styled-components'
+
+export const HyperLink = styled.a`
+  text-decoration: none;
+  transition: opacity 0.2s;
+  &:hover,
+  &.is-active {
+    opacity: 1;
+  }
+`

--- a/src/context/NotificationsManager.tsx
+++ b/src/context/NotificationsManager.tsx
@@ -7,6 +7,8 @@ import 'animate.css/animate.min.css'
 import 'react-toastify/dist/ReactToastify.css'
 import { CHAIN_ID } from '../constants'
 import { getNetworkName } from '../utils'
+import { HyperLink } from '../components/Hyperlink'
+import { Button } from '../components/Button'
 
 export enum Condition {
   SUCCESS = 'Complete',
@@ -40,13 +42,13 @@ const ToastsProvider: React.FC = (props) => {
           {txType}: Transaction {cond}
         </div>
         {txHash ? (
-          <a
+          <HyperLink
             href={getEtherscanTxUrl(wallet.chainId ?? Number(CHAIN_ID), txHash)}
             target="_blank"
             rel="noopener noreferrer"
           >
-            Etherscan
-          </a>
+            <Button>Check on Etherscan</Button>
+          </HyperLink>
         ) : null}
       </div>
     )

--- a/src/context/WalletManager.tsx
+++ b/src/context/WalletManager.tsx
@@ -125,7 +125,7 @@ const WalletProvider: React.FC = (props) => {
   }, [web3React])
 
   useEffect(() => {
-    const dataInterval = setInterval(() => dataReload(), 3000)
+    const dataInterval = setInterval(() => dataReload(), 3500)
     return () => {
       clearInterval(dataInterval)
     }

--- a/src/hooks/useTransactionDetails.ts
+++ b/src/hooks/useTransactionDetails.ts
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react'
 import { useWallet } from '../context/WalletManager'
-import { formatEther, parseEther } from '@ethersproject/units'
 import { Function_Name } from '../utils/decoder'
 import { Provider, Web3Provider } from '@ethersproject/providers'
 import { decodeInput } from '../utils/decoder'
@@ -13,6 +12,7 @@ export const getTransactionAmount = async (
   provider: Web3Provider | Provider
 ): Promise<string> => {
   const receipt = await provider.getTransactionReceipt(tx.hash)
+  if (!receipt) return 'Unknown'
   const logs = receipt.logs
 
   switch (function_name) {

--- a/src/pages/invest/index.tsx
+++ b/src/pages/invest/index.tsx
@@ -45,6 +45,7 @@ import { useFetchTxHistoryByAddress } from '../../hooks/useFetchTxHistoryByAddre
 import { getEtherscanTxUrl } from '../../utils/etherscan'
 import { useUserData } from '../../context/UserDataManager'
 import { useTransactionDetails } from '../../hooks/useTransactionDetails'
+import { HyperLink } from '../../components/Hyperlink'
 
 function Invest(): any {
   const { errors, makeToast } = useToasts()
@@ -724,13 +725,13 @@ function Invest(): any {
                   <TableData>{pendingtx.value}</TableData>
                   <TableData>{timeAgo(Number(Date.now()) * 1000)}</TableData>
                   <TableData>
-                    <a
+                    <HyperLink
                       href={getEtherscanTxUrl(wallet.chainId || Number(CHAIN_ID), pendingtx.hash)}
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      {shortenAddress(pendingtx.hash)}
-                    </a>
+                      <Button>{shortenAddress(pendingtx.hash)} </Button>
+                    </HyperLink>
                   </TableData>
                   <TableData>{pendingtx.status}</TableData>
                 </TableRow>
@@ -738,21 +739,25 @@ function Invest(): any {
             {txHistory.txList &&
               txHistory.txList.map((tx: any, i: number) => (
                 <TableRow key={tx.hash}>
-                  <TableData>{decodeInput(tx).function_name}</TableData>
                   <TableData>
-                    {transactionDetails.length > 0 ? transactionDetails[i] : <Loader width={10} height={10} />}
+                    {transactionDetails.length > 0 ? decodeInput(tx).function_name : <Loader width={10} height={10} />}
                   </TableData>
-                  <TableData>{timeAgo(Number(tx.timeStamp) * 1000)}</TableData>
+                  <TableData>{transactionDetails.length > 0 && transactionDetails[i]}</TableData>
+                  <TableData>{transactionDetails.length > 0 && timeAgo(Number(tx.timeStamp) * 1000)}</TableData>
                   <TableData>
-                    <a
-                      href={getEtherscanTxUrl(wallet.chainId || Number(CHAIN_ID), tx.hash)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {shortenAddress(tx.hash)}
-                    </a>
+                    {transactionDetails.length > 0 && (
+                      <HyperLink
+                        href={getEtherscanTxUrl(wallet.chainId || Number(CHAIN_ID), tx.hash)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <Button>{shortenAddress(tx.hash)} </Button>
+                      </HyperLink>
+                    )}
                   </TableData>
-                  <TableData>{tx.txreceipt_status ? 'Complete' : 'Failed'}</TableData>
+                  <TableData>
+                    {transactionDetails.length > 0 && (tx.txreceipt_status ? 'Complete' : 'Failed')}
+                  </TableData>
                 </TableRow>
               ))}
           </TableBody>

--- a/src/utils/decoder.ts
+++ b/src/utils/decoder.ts
@@ -38,28 +38,6 @@ export enum Function_Name {
   APPROVE = 'Approve',
 }
 
-export const getTransactionAmount = async (tx: any, provider: Web3Provider | Provider): Promise<string> => {
-  const receipt = await provider.getTransactionReceipt(tx.hash)
-  const logs = receipt.logs
-  const function_name = decodeInput(tx).function_name
-
-  switch (function_name) {
-    case Function_Name.DEPOSIT:
-    case Function_Name.WITHDRAW_VAULT:
-      const topics = logs[logs.length - 1].topics
-      return topics[topics.length - 1]
-    case Function_Name.DEPOSIT_ETH:
-    case Function_Name.DEPOSIT_CP:
-    case Function_Name.WITHDRAW_CP:
-    case Function_Name.WITHDRAW_REWARDS:
-    case Function_Name.DEPOSIT_LP:
-    case Function_Name.WITHDRAW_LP:
-      return logs[logs.length - 1].data
-    default:
-      return '0'
-  }
-}
-
 const getInterface = (toAddress: string) => {
   switch (toAddress) {
     case String(SOLACE_CONTRACT_ADDRESS).toLowerCase():


### PR DESCRIPTION
- created check to make sure receipt exists before looking into its logs
- This issue occurs when the user changes network when the app is in the middle of retrieving transaction details, which will result in a null error

![Screenshot (253)](https://user-images.githubusercontent.com/32408586/119774496-18b78c80-be77-11eb-8798-bd49343a11ee.png)
