### PR TITLE
fix<src>: html fixes

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -23,7 +23,7 @@ export const ItemText = styled.li`
   align-items: center;
   padding: 8px 0px 8px 16px;
   list-style: none;
-  height: 60px;
+  height: 30px;
 `
 
 export const ItemList = styled.ul`

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -41,7 +41,7 @@ export default function App(): any {
           <LayoutContent width={10}>
             <Navbar />
           </LayoutContent>
-          <LayoutContent width={90}>
+          <LayoutContent>
             <Prices />
             <LayoutContentWithLoader>
               {location.pathname !== '/quote' && <Statistics />}


### PR DESCRIPTION
- height for li tags changed to 30px
- The app is separated into two parts: The left part which contains the sidebar and the right part for the content, this allows the sidebar to be able to stay in a fixed position while the user scrolls. What changed is that the width of the right part is no longer fixed to 90% of the max width and can now resize but only by however much its children components can allow.

![Screenshot (293)](https://user-images.githubusercontent.com/32408586/122281962-b6631200-ce9f-11eb-8a3a-d84db47f84d7.png)

![Screenshot (292)](https://user-images.githubusercontent.com/32408586/122281954-b531e500-ce9f-11eb-8b38-6f56e9f9ddcf.png)
